### PR TITLE
fix: encode base64 string as a single line during encryption

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         id: exercise
         uses: ./
         with:
-          data: foobar
+          data: Provide a sufficiently long text to avoid encountering a 'bad decrypt' error.
           operation: encrypt
 
       - name: Verify
@@ -39,7 +39,7 @@ jobs:
           ENCRYPTED: ${{ steps.exercise.outputs.result }}
         run: |
           set -x
-          [[ "${#ENCRYPTED}" -ge 20 ]]
+          [[ "${#ENCRYPTED}" -ge 100 ]]
 
   test-decrypt:
     name: Test decrypt
@@ -64,4 +64,4 @@ jobs:
           DECRYPTED: ${{ steps.exercise.outputs.result }}
         run: |
           set -x
-          test "${DECRYPTED}" = "foobar"
+          test "${DECRYPTED}" = "Provide a sufficiently long text to avoid encountering a 'bad decrypt' error."

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
       run: |
         key="$(sha256sum <<<"${KEY}" | cut -d' ' -f1)"
         iv="$(sha256sum <<<"${IV}" | head -c 32)"
-        result="$(openssl enc -aes-256-cbc -K "${key}" -iv "${iv}" -base64 <<<"${DATA}")"
+        result="$(openssl enc -aes-256-cbc -K "${key}" -iv "${iv}" -base64 -A <<<"${DATA}")"
         echo "result=${result}" >> "${GITHUB_OUTPUT}"
       shell: bash
 


### PR DESCRIPTION
If the encrypted string is long, the following error may occur during decryption:

```
bad decrypt
40C795C66F7F0000:error:1C800064:Provider routines:ossl_cipher_unpadblock:bad decrypt:../providers/implementations/ciphers/ciphercommon_block.c:124:
```

To prevent this error, use the -A flag during decryption.
The -A flag ensures that the Base64-encoded string is written as a single line without line breaks.
For more details, refer to the following documentation:

- [OpenSSL Base64 Encoding Documentation](https://wiki.openssl.org/index.php/Enc#Base64_Encoding)

The document notes:

> These flags tell OpenSSL to apply Base64-encoding before or after the cryptographic operation.
> The -a and -base64 are equivalent. If you want to decode a base64 file it is necessary to use the -d option.
> **By default the encoded file has a line break every 64 characters**.
> To suppress this you can use in addition to -base64 the -A flag.
> This will produce a file with no line breaks at all. You can use these flags just for encoding Base64 without any ciphers involved.
